### PR TITLE
fix typo in check for Texture2D creation

### DIFF
--- a/Source/RuntimeImageLoader/Private/RuntimeImageReader.cpp
+++ b/Source/RuntimeImageLoader/Private/RuntimeImageReader.cpp
@@ -196,7 +196,7 @@ void URuntimeImageReader::BlockTillAllRequestsFinished()
                 ReadResult.OutTexture = TextureFactory->CreateTexture2D({ Request.ImageFilename, &ImageData });
 
                 FRuntimeRHITexture2DFactory RHITexture2DFactory(ReadResult.OutTexture, ImageData);
-                if (RHITexture2DFactory.Create())
+                if (!RHITexture2DFactory.Create())
                 {
                     ReadResult.OutError = FString::Printf(TEXT("Failed to create rhi texture 2D, pixel format: %d"), (int32)ImageData.PixelFormat);
                     continue;


### PR DESCRIPTION
Branch would execute when Create() function returned valid result, instead of the other way around.