### PR TITLE
Use file animation timings

### DIFF
--- a/Source/RuntimeImageLoader/Private/Helpers/GIFLoader.h
+++ b/Source/RuntimeImageLoader/Private/Helpers/GIFLoader.h
@@ -15,6 +15,7 @@ public:
 	virtual const int32 GetHeight() const = 0;
 	virtual const int32 GetTotalFrames() const = 0;
 	virtual const FColor* GetNextFrame(int32 FrameIndex) = 0;
+	virtual const float GetNextFrameDelay(int32 FrameIndex) = 0;
 };
 
 class FGIFLoaderFactory

--- a/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.cpp
+++ b/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.cpp
@@ -134,6 +134,8 @@ bool FNSGIFLoader::DecodeInternal(nsgif_t* gif, bool first)
 			return false;
 		}
 
+		Timestamps.Add(delay_cs * 10.f / 1000.f);
+
 		if (frame_new < frame_prev) {
 			// Must be an animation that loops. We only care about
 			// decoding each frame once in this utility.
@@ -196,5 +198,10 @@ const FColor* FNSGIFLoader::GetNextFrame(int32 FrameIndex)
 		// Handling the case where the index is out of bounds
 		return &FColor::Black; // return a default FColor value, like FColor::Black
 	}
+}
+
+const float FNSGIFLoader::GetNextFrameDelay(int32 FrameIndex)
+{
+	return Timestamps[FrameIndex];
 }
 #endif //WITH_LIBNSGIF

--- a/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.h
+++ b/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.h
@@ -29,6 +29,7 @@ public: /** Gif Data Method */
 
 public: /** Get Next Frame Texture Data*/
     const FColor* GetNextFrame(int32 FrameIndex) override;
+	const float GetNextFrameDelay(int32 FrameIndex) override;
 	bool DecodeGIF(TArray<uint8>&& GifBytes) override;
 
 protected: /** Bitmap Callbacks Methods */
@@ -44,6 +45,7 @@ private: /** Gif Data*/
 	nsgif_t* Gif;
 	const nsgif_info_t* Info;
 	TArray<FColor> TextureData;
+	TArray<float> Timestamps;
 
 	int32 Width = -1;
 	int32 Height = -1;

--- a/Source/RuntimeImageLoader/Private/Helpers/WEBPGIFLoader.cpp
+++ b/Source/RuntimeImageLoader/Private/Helpers/WEBPGIFLoader.cpp
@@ -51,6 +51,11 @@ const FColor* FWEBPGIFLoader::GetNextFrame(int32 FrameIndex)
     }
 }
 
+const float FWEBPGIFLoader::GetNextFrameDelay(int32 FrameIndex)
+{
+    return Timestamps[FrameIndex];
+}
+
 
 bool FWEBPGIFLoader::DecodeGIF(TArray<uint8>&& GifBytes)
 {
@@ -121,6 +126,7 @@ bool FWEBPGIFLoader::DecodeGIF(TArray<uint8>&& GifBytes)
                     SetError("Failed to decode .webp frame. Please check input data is valid!");
                     return false;
                 }
+                Timestamps.Add(timestamp / 1000.f);
                
                 FPlatformMemory::Memcpy((uint8_t*)TextureData.GetData() + FrameInd * FrameBytes, DecodedData, FrameBytes);
                 ++FrameInd;
@@ -134,7 +140,7 @@ bool FWEBPGIFLoader::DecodeGIF(TArray<uint8>&& GifBytes)
 
         return true;
     }
-
+    Timestamps.Add(100.f);
     TotalFrameCount = 1;
 
     TextureData.SetNumZeroed(GetWidth() * GetHeight());

--- a/Source/RuntimeImageLoader/Private/Helpers/WEBPGIFLoader.h
+++ b/Source/RuntimeImageLoader/Private/Helpers/WEBPGIFLoader.h
@@ -29,7 +29,8 @@ public: /** Gif Data Method */
 
 public: /** Get Next Frame Texture Data*/
     const FColor* GetNextFrame(int32 FrameIndex) override;
-    bool DecodeGIF(TArray<uint8>&& GifBytes) override;
+	const float GetNextFrameDelay(int32 FrameIndex);
+	bool DecodeGIF(TArray<uint8>&& GifBytes) override;
 
 	static bool HasValidWebpHeader(const TArray<uint8>& GifBytes);
 
@@ -38,6 +39,7 @@ private:
 
 private:
 	TArray<FColor> TextureData;
+	TArray<float> Timestamps;
 
 	int32 Width = -1;
 	int32 Height = -1;

--- a/Source/RuntimeImageLoader/Private/Texture2DAnimation/AnimatedTexture2D.cpp
+++ b/Source/RuntimeImageLoader/Private/Texture2DAnimation/AnimatedTexture2D.cpp
@@ -37,7 +37,7 @@ void UAnimatedTexture2D::Tick(float DeltaTime)
 	if (!Decoder) return;
 
 	FrameTime += DeltaTime * PlayRate;
-	if (FrameTime < DefaultFrameDelay)
+	if (FrameTime < Decoder->GetNextFrameDelay(CurrentFrame))
 		return;
 
 	FrameTime = 0;


### PR DESCRIPTION
The animation data from the files wasn't being used. This was a simple way I made it work. Static images work as well. I was using it for Twitch emotes with another plugin. DefaultFrameDelay is going unused as is. I wasn't sure what to do with it.