### PR TITLE
Fix #37 issues.

### DIFF
--- a/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.cpp
+++ b/Source/RuntimeImageLoader/Private/Helpers/NSGIFLoader.cpp
@@ -119,6 +119,7 @@ bool FNSGIFLoader::DecodeInternal(nsgif_t* gif, bool first)
 	const int32 TotalPixels = info->frame_count * info->width * info->height;
 	TextureData.Empty(TotalPixels);
 	TextureData.AddUninitialized(TotalPixels);
+	Timestamps.Reserve(info->frame_count);
 
 	// Decode the frames
 	while (true) {
@@ -133,8 +134,6 @@ bool FNSGIFLoader::DecodeInternal(nsgif_t* gif, bool first)
 			Warning("nsgif_frame_prepare");
 			return false;
 		}
-
-		Timestamps.Add(delay_cs * 10.f / 1000.f);
 
 		if (frame_new < frame_prev) {
 			// Must be an animation that loops. We only care about
@@ -169,6 +168,8 @@ bool FNSGIFLoader::DecodeInternal(nsgif_t* gif, bool first)
 			}
 		}
 
+		Timestamps.Emplace(delay_cs * 10.f / 1000.f);
+
 		if (delay_cs == NSGIF_INFINITE) 
 		{
 			// This frame is the last.
@@ -202,6 +203,10 @@ const FColor* FNSGIFLoader::GetNextFrame(int32 FrameIndex)
 
 const float FNSGIFLoader::GetNextFrameDelay(int32 FrameIndex)
 {
+	if (FrameIndex > GetTotalFrames() - 1)
+	{
+		FrameIndex = 0;
+	}
 	return Timestamps[FrameIndex];
 }
 #endif //WITH_LIBNSGIF


### PR DESCRIPTION
There was some issues with #37 . I got around to working on making 7TV emotes work in my project and the animated WebP's were crashing from out of bounds. Gifs worked because the Add was in the wrong place giving it an extra index. I guess I did a poor job testing them than I thought.

The WebP animation speeds were wrong, but not because of what I did directly. WebPAnimDecoderGetNext was adding the timestamp values each call. So I worked around that.

I also changed the Timestamps array to use Reserve and Emplace since the size is known. Everything should be working properly now.

As an aside. I don't know much about WebP's pixel format. I'm using them for screen space widgets and RGBA is displaying incorrectly for me. I had to flip them around to BGRA. https://cdn.7tv.app/emote/01GAZ199Z8000FEWHS6AT5QZV0/4x.webp as an example of what I was using.