### PR TITLE
Add frame stepping functions for animated images.

### DIFF
--- a/Source/RuntimeImageLoader/Private/Texture2DAnimation/AnimatedTexture2D.cpp
+++ b/Source/RuntimeImageLoader/Private/Texture2DAnimation/AnimatedTexture2D.cpp
@@ -36,6 +36,8 @@ void UAnimatedTexture2D::Tick(float DeltaTime)
 
 	if (!Decoder) return;
 
+	if (CurrentFrame > Decoder->GetTotalFrames() - 1 && bLooping) CurrentFrame = 0;
+
 	FrameTime += DeltaTime * PlayRate;
 	if (FrameTime < Decoder->GetNextFrameDelay(CurrentFrame))
 		return;
@@ -140,6 +142,25 @@ void UAnimatedTexture2D::PlayFromStart()
 	bPlaying = true;
 	CurrentFrame = 0;
 }
+
+void UAnimatedTexture2D::StepForward()
+{
+	CurrentFrame++;
+	RenderFrameToTexture();
+}
+
+void UAnimatedTexture2D::StepBackward()
+{
+	CurrentFrame--;
+	RenderFrameToTexture();
+}
+
+void UAnimatedTexture2D::GotoFrame(const int32 NewFrame)
+{
+	CurrentFrame = NewFrame;
+	RenderFrameToTexture();
+}
+
 
 void UAnimatedTexture2D::Stop()
 {

--- a/Source/RuntimeImageLoader/Public/Texture2DAnimation/AnimatedTexture2D.h
+++ b/Source/RuntimeImageLoader/Public/Texture2DAnimation/AnimatedTexture2D.h
@@ -46,6 +46,15 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = RuntimeAnimatedTexture)
 	void PlayFromStart();
+	
+	UFUNCTION(BlueprintCallable, Category = RuntimeAnimatedTexture)
+	void StepForward();
+	
+	UFUNCTION(BlueprintCallable, Category = RuntimeAnimatedTexture)
+	void StepBackward();
+
+	UFUNCTION(BlueprintCallable, Category = RuntimeAnimatedTexture)
+	void GotoFrame(int32 NewFrame);
 
 	UFUNCTION(BlueprintCallable, Category = RuntimeAnimatedTexture)
 	void Stop();
@@ -165,7 +174,7 @@ private:
 
 	float FrameDelay = 0.0f;
 	float FrameTime = 0.0f;
-	bool bPlaying = true;
+	bool bPlaying = false;
 
 private:
 	int32 CurrentFrame = 0;


### PR DESCRIPTION
This adds functions allowing for frame-by-frame control of animated gifs and webp. It also sets the default play state after load to stopped so it can be manually stepped, but auto-play after load should probably be a boolean on the load gif node.